### PR TITLE
Add downloads.aredn.org as a default mirror

### DIFF
--- a/scripts/download.pl
+++ b/scripts/download.pl
@@ -198,6 +198,7 @@ foreach my $mirror (@ARGV) {
 	}
 }
 
+push @mirrors, 'http://downloads.aredn.org/sources';
 #push @mirrors, 'http://mirror1.openwrt.org';
 push @mirrors, 'http://mirror2.openwrt.org/sources';
 push @mirrors, 'http://downloads.openwrt.org/sources';


### PR DESCRIPTION
http://downloads.aredn.org/sources/ should maintain a copy of
all source downloads used as part of image generation.

It is periodically updated from the buildbots 'dl/' folder adding
new files that have previously not been added.

No plans currently exist to trim the contents of the folder, and
no version that is still under active support will have its files
removed from that folder making it one of the best locations
to pull copies of files from when they are not located at the
origional source.

Change-Id: I47cf203ca007d372f0879307d1c12696e283034b